### PR TITLE
Correct terraform 'resource' snippet

### DIFF
--- a/snippets/terraform-mode/resource
+++ b/snippets/terraform-mode/resource
@@ -2,6 +2,6 @@
 # name: resource
 # key: res
 # --
-resource "${1:name}" {
+resource "${1:type}" "${2:name}" {
          $0
 }


### PR DESCRIPTION
Type definition was missing. As the official Terraform documentation states:

> The resource block defines a resource that exists within the infrastructure. A resource might be a physical component such as an EC2 instance, or it can be a logical resource such as a Heroku application.

From: https://www.terraform.io/intro/getting-started/build.html#configuration